### PR TITLE
add opacity into addLayer

### DIFF
--- a/geetools/ui/maptool.py
+++ b/geetools/ui/maptool.py
@@ -100,7 +100,7 @@ class Map(folium.Map):
 
         def addImage(image):
             params = get_image_tile(image, visParams, show, opacity)
-            layer = folium.raster_layers.TileLayer(attr=params['attribution'],
+            layer = folium.TileLayer(attr=params['attribution'],
                                      name=name,
                                      opacity=params['opacity'],
                                      overlay=params['overlay'],


### PR DESCRIPTION
Add opacity parameter into the folium.TileLayer() call

Only works with last folium version that is installed directly from GitHub with
`!pip install git+https://github.com/python-visualization/folium`
as this
`!pip install folium`
does not have a fix in folium to pass opacity to leafletjs