### PR TITLE
Added .toCloudStorage function to batch.imagecollection

### DIFF
--- a/geetools/batch/imagecollection.py
+++ b/geetools/batch/imagecollection.py
@@ -72,46 +72,35 @@ def toDrive(collection, folder, namePattern='{id}', scale=30,
                 raise e
 
 
-""" modified from toDrive at https://github.com/gee-community/gee_tools/blob/master/geetools/batch/imagecollection.py"""
-def toCloudStorage(collection, bucket, folder='', namePattern='{id}', scale=30,
-            dataType="float", region=None, datePattern=None, **kwargs):
-    """ Upload all images from one collection to Google Drive. You can use
+def toCloudStorage(collection, bucket, folder='', namePattern='{id}', region=None, scale=30,
+            dataType="float", datePattern=None, **kwargs):
+    """ Upload all images from one collection to Google Cloud Storage. You can use
     the same arguments as the original function
-    ee.batch.export.image.toDrive
+    ee.batch.export.image.toCloudStorage
 
-    config: A dictionary that will be copied and used as parameters
-    for the task:
-    - region: The lon,lat coordinates for a LinearRing or Polygon
-      specifying the region to export. Can be specified as a nested
-      lists of numbers or a serialized string. Defaults to the image's
-      region.
-    - scale: The resolution in meters per pixel.
-      Defaults to the native resolution of the image assset unless
-      a crs_transform is specified.
-    - maxPixels: The maximum allowed number of pixels in the exported
-      image. The task will fail if the exported region covers
-      more pixels in the specified projection. Defaults to 100,000,000.
-    - crs: The coordinate reference system of the exported image's
-      projection. Defaults to the image's default projection.
-    - crs_transform: A comma-separated string of 6 numbers describing
-      the affine transform of the coordinate reference system of the
-      exported image's projection, in the order: xScale, xShearing,
-      xTranslation, yShearing, yScale and yTranslation. Defaults to
-      the image's native CRS transform.
-    - dimensions: The dimensions of the exported image. Takes either a
-      single positive integer as the maximum dimension or
-      "WIDTHxHEIGHT" where WIDTH and HEIGHT are each positive integers.
-    - skipEmptyTiles: If true, skip writing empty (i.e. fully-masked)
-      image tiles. Defaults to false.
-    If exporting to Google Drive (default):
-    - driveFolder: The name of a unique folder in your Drive account to
-      export into. Defaults to the root of the drive.
-    - driveFileNamePrefix: The Google Drive filename for the export.
-      Defaults to the name of the task.
-    If exporting to Google Cloud Storage:
-    - outputBucket: The name of a Cloud Storage bucket for the export.
-    - outputPrefix: Cloud Storage object name prefix for the export.
-
+    :param collection: Collection to upload
+    :type collection: ee.ImageCollection
+    :param bucket: Google Cloud Storage bucket name
+    :type folder: str
+    :param folder: Google Cloud Storage prefix to export the images to
+    :type folder: str
+    :param namePattern: pattern for the name. See make_name function
+    :type namePattern: str
+    :param region: area to upload. Defualt to the footprint of the first
+        image in the collection
+    :type region: ee.Geometry.Rectangle or ee.Feature
+    :param scale: scale of the image (side of one pixel). Defults to 30
+        (Landsat resolution)
+    :type scale: int
+    :param dataType: as downloaded images **must** have the same data type
+        in all bands, you have to set it here. Can be one of: "float",
+        "double", "int", "Uint8", "Int8" or a casting function like
+        *ee.Image.toFloat*
+    :type dataType: str
+    :param datePattern: pattern for date if specified in namePattern.
+        Defaults to 'yyyyMMdd'
+    :type datePattern: str
+    
     """
     # empty tasks list
     tasklist = []

--- a/geetools/batch/imagecollection.py
+++ b/geetools/batch/imagecollection.py
@@ -73,7 +73,7 @@ def toDrive(collection, folder, namePattern='{id}', scale=30,
 
 
 def toCloudStorage(collection, bucket, folder=None, namePattern='{id}', region=None, scale=30,
-            dataType="float", datePattern=None, **kwargs):
+            dataType="float", datePattern=None, verbose=False, **kwargs):
     """ Upload all images from one collection to Google Cloud Storage. You can use
     the same arguments as the original function
     ee.batch.export.image.toCloudStorage
@@ -130,11 +130,11 @@ def toCloudStorage(collection, bucket, folder=None, namePattern='{id}', region=N
                                                  path=path,
                                                  region=region,
                                                  scale=scale,
-                                                 maxPixels=int(1e12), **kwargs)
+                                                 **kwargs)
             task.start()
             tasklist.append(task)
-            print("adding task {} to list".format(name))
-
+            if verbose:
+                print("adding task {} to list".format(name))
             n += 1
 
         except Exception as e:

--- a/geetools/batch/imagecollection.py
+++ b/geetools/batch/imagecollection.py
@@ -72,7 +72,7 @@ def toDrive(collection, folder, namePattern='{id}', scale=30,
                 raise e
 
 
-def toCloudStorage(collection, bucket, folder='', namePattern='{id}', region=None, scale=30,
+def toCloudStorage(collection, bucket, folder=None, namePattern='{id}', region=None, scale=30,
             dataType="float", datePattern=None, **kwargs):
     """ Upload all images from one collection to Google Cloud Storage. You can use
     the same arguments as the original function
@@ -100,7 +100,6 @@ def toCloudStorage(collection, bucket, folder='', namePattern='{id}', region=Non
     :param datePattern: pattern for date if specified in namePattern.
         Defaults to 'yyyyMMdd'
     :type datePattern: str
-    
     """
     # empty tasks list
     tasklist = []
@@ -120,7 +119,10 @@ def toCloudStorage(collection, bucket, folder='', namePattern='{id}', region=Non
             # convert data type
             img = utils.convertDataType(dataType)(img)
 
-            path = folder + "/" + name
+            if folder is not None:
+                path = folder + "/" + name
+            else:
+                path = name
 
             task = ee.batch.Export.image.toCloudStorage(image=img,
                                                  description=name,

--- a/notebooks/batch/exportToGCS.ipynb
+++ b/notebooks/batch/exportToGCS.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Exporting collection to Cloud Storage\n",
     "\n",
-    "### toCloudStorage(collection, bucket=\"opencrops\", folder='', namePattern='{id}', scale=30, dataType=\"float\", region=None, datePattern=None):\n",
+    "### toCloudStorage(collection, bucket=\"opencrops\", folder=None, namePattern='{id}', scale=30, dataType=\"float\", region=None, datePattern=None):\n",
     "Export an image clipped by features (Polygons). You can use the same arguments as the original function ee.batch.export.image.toDrive\n",
     "\n",
     "**Parameters**\n",
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
     "# and change this bucket with a bucket you have write access\n",
     "BUCKET = \"opencrops\"\n",
     "\n",
-    "batch.imagecollection.toCloudStorage(collection, bucket=BUCKET, folder='', namePattern='{id}', scale=30,\n",
+    "batch.imagecollection.toCloudStorage(collection, bucket=BUCKET, folder=\"geetools\", namePattern='{id}', scale=30,\n",
     "            dataType=\"float\", region=None, datePattern=None)"
    ]
   },

--- a/notebooks/batch/exportToGCS.ipynb
+++ b/notebooks/batch/exportToGCS.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exporting collection to Cloud Storage\n",
+    "\n",
+    "### toCloudStorage(collection, bucket=\"opencrops\", folder='', namePattern='{id}', scale=30, dataType=\"float\", region=None, datePattern=None):\n",
+    "Export an image clipped by features (Polygons). You can use the same arguments as the original function ee.batch.export.image.toDrive\n",
+    "\n",
+    "**Parameters**\n",
+    "\n",
+    "- collection: image collection\n",
+    "- bucket: GCS bucket\n",
+    "- folder: same as ee.Export\n",
+    "- name: name of the resulting image. If `None` uses image's ID\n",
+    "- scale: same as ee.Export. Default to 1000\n",
+    "- dataType: as downloaded images **must** have the same data type in all\n",
+    "    bands, you have to set it here. Can be one of: \"float\", \"double\", \"int\",\n",
+    "    \"Uint8\", \"Int8\" or a casting function like *ee.Image.toFloat*\n",
+    "- region: geometry to clip export\n",
+    "- kwargs: keyword arguments that will be passed to ee.batch.export.image.toCloudStorage\n",
+    "\n",
+    "Return a list of all tasks (for further processing/checking)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import sys\n",
+    "sys.path.append(\"../..\")\n",
+    "ee.Initialize()\n",
+    "from geetools import batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get an Image Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p1 = ee.Geometry.Point([-71,-42])\n",
+    "feat1 = ee.Feature(p1.buffer(1000), {'site': 1})\n",
+    "fc = ee.FeatureCollection([feat1])\n",
+    "collection = ee.ImageCollection('COPERNICUS/S2').filterBounds(fc.geometry()).filterDate(\"2015-01-01\",\"2015-12-01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "adding task 20150825T143316_20150825T144048_T19GCP to list\n",
+      "adding task 20150825T143316_20161001T010844_T19GCP to list\n",
+      "adding task 20150825T144048_20160417T022845_T19GCP to list\n",
+      "adding task 20151123T142942_20170221T180430_T19GCP to list\n"
+     ]
+    }
+   ],
+   "source": [
+    "# please ensure that you have a default project enabled\n",
+    "# and change this bucket with a bucket you have write access\n",
+    "BUCKET = \"opencrops\"\n",
+    "\n",
+    "batch.imagecollection.toCloudStorage(collection, bucket=BUCKET, folder='', namePattern='{id}', scale=30,\n",
+    "            dataType=\"float\", region=None, datePattern=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/batch/exportToGCS.ipynb
+++ b/notebooks/batch/exportToGCS.ipynb
@@ -78,16 +78,29 @@
     "# and change this bucket with a bucket you have write access\n",
     "BUCKET = \"opencrops\"\n",
     "\n",
-    "batch.imagecollection.toCloudStorage(collection, bucket=BUCKET, folder=\"geetools\", namePattern='{id}', scale=30,\n",
-    "            dataType=\"float\", region=None, datePattern=None)"
+    "batch.imagecollection.toCloudStorage(collection, bucket=BUCKET, folder=\"geetools\", scale=30, verbose=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gs://opencrops/geetools/20150825T143316_20150825T144048_T19GCP.tif\r\n",
+      "gs://opencrops/geetools/20150825T143316_20161001T010844_T19GCP.tif\r\n",
+      "gs://opencrops/geetools/20150825T144048_20160417T022845_T19GCP.tif\r\n",
+      "gs://opencrops/geetools/20151123T142942_20170221T180430_T19GCP.tif\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# check the storage bucket via the gsutil tool\n",
+    "!gsutil ls gs://opencrops/geetools"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Dear @fitoprincipe, Dear all,

Thanks for your great work on this package! I really appreciate the work that you put in this project. It made my work on Google Earth Engine and exporting data much more enjoyable! 

I recently needed to export some image collections directly to GCS instead of my Drive.
So, I added `.toCloudStorage` to the `batch.imagecollection` functions which is based on `ee.batch.Export.image.toCloudStorage` similar to `.toDrive`. 
I tried to stay as close to the `.toDrive` function as possible. 
I added a working example as a notebook here `notebooks/batch/exportToGCS.ipynb`. This notebook was modified from `notebooks/batch/exportByFeat.ipynb`. To reproduce the results, you would need a bucket with write access and a default GCS project.

Let me know what should be changed to make it compatible with the current codebase. I am happy to help, contribute, and make this feature accessible to others, too.