### PR TITLE
feat: n_images_per_interval prop on reduceInterval

### DIFF
--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -957,9 +957,7 @@ class ImageCollectionAccessor:
         values = keys.map(lambda p: self._obj.aggregate_array(p))
         return ee.Dictionary.fromLists(keys, values)
 
-    def groupInterval(
-        self, unit: str = "month", duration: int = 1
-    ) -> ee.List:
+    def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
         """Transform the :py:class:`ee.ImageCollection` into a list of smaller collection of the specified duration.
 
         For example using unit as "month" and duration as 1, the :py:class:`ee.ImageCollection` will be transformed
@@ -1006,9 +1004,7 @@ class ImageCollectionAccessor:
             ic = ee.ImageCollection(ic)
             return ic.set({sizeName: ic.size()})
 
-        imageCollectionList = (
-            imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0))
-        )
+        imageCollectionList = imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0))
 
         return ee.List(imageCollectionList)
 
@@ -1055,7 +1051,7 @@ class ImageCollectionAccessor:
         """
         # Default property name that keeps the number of images used for the reduction in each interval
         sizeName = "__geetools_generated_size__"
-        
+
         # create a list of image collections to be reduced
         # Every subcollection is sorted in case one use the "first" reducer
         imageCollectionList = self.groupInterval(unit, duration)
@@ -1097,7 +1093,9 @@ class ImageCollectionAccessor:
         reducedImagesList = imageCollectionList.map(reduce)
 
         if not count_images_per_interval:
-            reducedImagesList = reducedImagesList.map(lambda i: ee.Image(i).copyProperties(i, exclude=[sizeName]))
+            reducedImagesList = reducedImagesList.map(
+                lambda i: ee.Image(i).copyProperties(i, exclude=[sizeName])
+            )
 
         # set back the original properties
         propertyNames = self._obj.propertyNames()

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -998,7 +998,7 @@ class ImageCollectionAccessor:
         ic = self._obj
         toCopy = ic.first().propertyNames()
 
-        # Removing sizeName prop acoording to count_images_per_interval flag
+        # Removing sizeName prop according to count_images_per_interval flag
         if not count_images_per_interval:
             toCopy = toCopy.filter(ee.Filter.neq("item", sizeName))
 

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -958,7 +958,7 @@ class ImageCollectionAccessor:
         return ee.Dictionary.fromLists(keys, values)
 
     def groupInterval(
-        self, unit: str = "month", duration: int = 1, count_images_per_interval: bool = False
+        self, unit: str = "month", duration: int = 1
     ) -> ee.List:
         """Transform the :py:class:`ee.ImageCollection` into a list of smaller collection of the specified duration.
 
@@ -970,7 +970,6 @@ class ImageCollectionAccessor:
         Args:
             unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
-            count_images_per_interval: Whether to keep the property `__geetools_generated_size__` with the number of images used for the reduction in each interval.
 
         Returns:
             A list of :py:class:`ee.ImageCollection` grouped by interval
@@ -992,15 +991,7 @@ class ImageCollectionAccessor:
                 print(split.getInfo())
         """
         sizeName = "__geetools_generated_size__"  # set generated properties name
-
-        # create an ic variable to avoid calling self._obj multiple times
-        # and extract the property names to copy
         ic = self._obj
-        toCopy = ic.first().propertyNames()
-
-        # Removing sizeName prop according to count_images_per_interval flag
-        if not count_images_per_interval:
-            toCopy = toCopy.filter(ee.Filter.neq("item", sizeName))
 
         # transform the interval into a duration in milliseconds
         # I can use the DateRangeAccessor as it's imported earlier in the __init__.py file
@@ -1015,12 +1006,8 @@ class ImageCollectionAccessor:
             ic = ee.ImageCollection(ic)
             return ic.set({sizeName: ic.size()})
 
-        def delete_size_property(ic):
-            ic = ee.ImageCollection(ic)
-            return ee.ImageCollection(ic.copyProperties(ic, properties=toCopy))
-
         imageCollectionList = (
-            imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0)).map(delete_size_property)
+            imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0))
         )
 
         return ee.List(imageCollectionList)
@@ -1066,9 +1053,12 @@ class ImageCollectionAccessor:
                 reduced = collection.geetools.reduceInterval("mean", "month", 1)
                 print(reduced.getInfo())
         """
+        # Default property name that keeps the number of images used for the reduction in each interval
+        sizeName = "__geetools_generated_size__"
+        
         # create a list of image collections to be reduced
         # Every subcollection is sorted in case one use the "first" reducer
-        imageCollectionList = self.groupInterval(unit, duration, count_images_per_interval)
+        imageCollectionList = self.groupInterval(unit, duration)
 
         # create a reducer from user parameters
         red = getattr(ee.Reducer, reducer)() if isinstance(reducer, str) else reducer
@@ -1098,12 +1088,16 @@ class ImageCollectionAccessor:
             ic = ee.ImageCollection(ic)
             start = ic.aggregate_min("system:time_start")
             end = ic.aggregate_max("system:time_end")
+            count = ic.get(sizeName)
             firstImg = ic.first()
             propertyNames = firstImg.propertyNames()
             image = ic.reduce(red).rename(bandNames).copyProperties(firstImg, propertyNames)
-            return image.set("system:time_start", start, "system:time_end", end)
+            return image.set("system:time_start", start, "system:time_end", end, sizeName, count)
 
         reducedImagesList = imageCollectionList.map(reduce)
+
+        if not count_images_per_interval:
+            reducedImagesList = reducedImagesList.map(lambda i: ee.Image(i).copyProperties(i, exclude=[sizeName]))
 
         # set back the original properties
         propertyNames = self._obj.propertyNames()

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -957,7 +957,7 @@ class ImageCollectionAccessor:
         values = keys.map(lambda p: self._obj.aggregate_array(p))
         return ee.Dictionary.fromLists(keys, values)
 
-    def groupInterval(self, unit: str = "month", duration: int = 1) -> ee.List:
+    def groupInterval(self, unit: str = "month", duration: int = 1, count_images_per_interval: bool = False) -> ee.List:
         """Transform the :py:class:`ee.ImageCollection` into a list of smaller collection of the specified duration.
 
         For example using unit as "month" and duration as 1, the :py:class:`ee.ImageCollection` will be transformed
@@ -968,6 +968,7 @@ class ImageCollectionAccessor:
         Args:
             unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
+            count_images_per_interval: Whether to add the property `n_images_per_interval` with the number of images used for the reduction in each interval.
 
         Returns:
             A list of :py:class:`ee.ImageCollection` grouped by interval
@@ -988,7 +989,7 @@ class ImageCollectionAccessor:
                 split = collection.geetools.groupInterval("month", 1)
                 print(split.getInfo())
         """
-        sizeName = "__geetools_generated_size__"  # set generated properties name
+        sizeName = "n_images_per_interval"  # set generated properties name
 
         # create an ic variable to avoid calling self._obj multiple times
         # and extract the property names to copy
@@ -1011,10 +1012,11 @@ class ImageCollectionAccessor:
         def delete_size_property(ic):
             ic = ee.ImageCollection(ic)
             return ee.ImageCollection(ic.copyProperties(ic, properties=toCopy))
+        
+        imageCollectionList = imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0))
 
-        imageCollectionList = (
-            imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0)).map(delete_size_property)
-        )
+        if not count_images_per_interval:
+            imageCollectionList = imageCollectionList.map(delete_size_property)
 
         return ee.List(imageCollectionList)
 
@@ -1061,16 +1063,7 @@ class ImageCollectionAccessor:
         """
         # create a list of image collections to be reduced
         # Every subcollection is sorted in case one use the "first" reducer
-        imageCollectionList = self.groupInterval(unit, duration)
-
-        # add the number of images per interval as a property if requested
-        if count_images_per_interval:
-            def add_count(ic):
-                ic = ee.ImageCollection(ic)
-                count = ic.size()
-                return ic.set("n_images_per_interval", count)
-
-            imageCollectionList = imageCollectionList.map(add_count)
+        imageCollectionList = self.groupInterval(unit, duration, count_images_per_interval)
 
         # create a reducer from user parameters
         red = getattr(ee.Reducer, reducer)() if isinstance(reducer, str) else reducer

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -1024,6 +1024,7 @@ class ImageCollectionAccessor:
         unit: str = "month",
         duration: int = 1,
         keep_original_names: bool = True,
+        count_images_per_interval: bool = False,
     ) -> ee.ImageCollection:
         """Reduce the images included in the same duration interval using the provided reducer.
 
@@ -1037,6 +1038,7 @@ class ImageCollectionAccessor:
             unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
             keep_original_names: Whether to keep the original band names or not. This is a workaround to preserve older behaviour, it should disappear in the future.
+            count_images_per_interval: Whether to add the property `n_images_per_interval` with the number of images used for the reduction in each interval.
 
         Returns:
             A new :py:class:`ee.ImageCollection` with the reduced images.
@@ -1060,6 +1062,15 @@ class ImageCollectionAccessor:
         # create a list of image collections to be reduced
         # Every subcollection is sorted in case one use the "first" reducer
         imageCollectionList = self.groupInterval(unit, duration)
+
+        # add the number of images per interval as a property if requested
+        if count_images_per_interval:
+            def add_count(ic):
+                ic = ee.ImageCollection(ic)
+                count = ic.size()
+                return ic.set("n_images_per_interval", count)
+
+            imageCollectionList = imageCollectionList.map(add_count)
 
         # create a reducer from user parameters
         red = getattr(ee.Reducer, reducer)() if isinstance(reducer, str) else reducer

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -957,7 +957,9 @@ class ImageCollectionAccessor:
         values = keys.map(lambda p: self._obj.aggregate_array(p))
         return ee.Dictionary.fromLists(keys, values)
 
-    def groupInterval(self, unit: str = "month", duration: int = 1, count_images_per_interval: bool = False) -> ee.List:
+    def groupInterval(
+        self, unit: str = "month", duration: int = 1, count_images_per_interval: bool = False
+    ) -> ee.List:
         """Transform the :py:class:`ee.ImageCollection` into a list of smaller collection of the specified duration.
 
         For example using unit as "month" and duration as 1, the :py:class:`ee.ImageCollection` will be transformed
@@ -1016,7 +1018,7 @@ class ImageCollectionAccessor:
         def delete_size_property(ic):
             ic = ee.ImageCollection(ic)
             return ee.ImageCollection(ic.copyProperties(ic, properties=toCopy))
-        
+
         imageCollectionList = (
             imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0)).map(delete_size_property)
         )

--- a/geetools/ee_image_collection.py
+++ b/geetools/ee_image_collection.py
@@ -968,7 +968,7 @@ class ImageCollectionAccessor:
         Args:
             unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
-            count_images_per_interval: Whether to add the property `n_images_per_interval` with the number of images used for the reduction in each interval.
+            count_images_per_interval: Whether to keep the property `__geetools_generated_size__` with the number of images used for the reduction in each interval.
 
         Returns:
             A list of :py:class:`ee.ImageCollection` grouped by interval
@@ -989,12 +989,16 @@ class ImageCollectionAccessor:
                 split = collection.geetools.groupInterval("month", 1)
                 print(split.getInfo())
         """
-        sizeName = "n_images_per_interval"  # set generated properties name
+        sizeName = "__geetools_generated_size__"  # set generated properties name
 
         # create an ic variable to avoid calling self._obj multiple times
         # and extract the property names to copy
         ic = self._obj
         toCopy = ic.first().propertyNames()
+
+        # Removing sizeName prop acoording to count_images_per_interval flag
+        if not count_images_per_interval:
+            toCopy = toCopy.filter(ee.Filter.neq("item", sizeName))
 
         # transform the interval into a duration in milliseconds
         # I can use the DateRangeAccessor as it's imported earlier in the __init__.py file
@@ -1013,10 +1017,9 @@ class ImageCollectionAccessor:
             ic = ee.ImageCollection(ic)
             return ee.ImageCollection(ic.copyProperties(ic, properties=toCopy))
         
-        imageCollectionList = imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0))
-
-        if not count_images_per_interval:
-            imageCollectionList = imageCollectionList.map(delete_size_property)
+        imageCollectionList = (
+            imageCollectionList.map(add_size).filter(ee.Filter.gt(sizeName, 0)).map(delete_size_property)
+        )
 
         return ee.List(imageCollectionList)
 
@@ -1040,7 +1043,7 @@ class ImageCollectionAccessor:
             unit: The unit of time to split the collection. Available units: ``year``, ``month``, ``week``, ``day``, ``hour``, ``minute`` or ``second``.
             duration: The duration of each split.
             keep_original_names: Whether to keep the original band names or not. This is a workaround to preserve older behaviour, it should disappear in the future.
-            count_images_per_interval: Whether to add the property `n_images_per_interval` with the number of images used for the reduction in each interval.
+            count_images_per_interval: Whether to keep the property `__geetools_generated_size__` with the number of images used for the reduction in each interval.
 
         Returns:
             A new :py:class:`ee.ImageCollection` with the reduced images.

--- a/tests/test_ImageCollection.py
+++ b/tests/test_ImageCollection.py
@@ -373,6 +373,25 @@ class TestReduceInterval:
         firstImg = ic.first()
         assert "system:id" in firstImg.propertyNames().getInfo()
 
+    def test_reduce_interval_with_count_images_per_interval(self, jaxa_rainfall):
+        # get 3 month worth of data and group it with default parameters
+        ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
+        reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
+        firstImg = reduced.first()
+        assert "n_images_per_interval" in firstImg.propertyNames().getInfo()
+
+    def test_reduce_interval_with_count_images_per_interval_count(self, jaxa_rainfall):
+        ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
+        reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
+        firstImg = reduced.first()
+        assert firstImg.get('n_images_per_interval').getInfo() == 24
+
+    def test_reduce_interval_with_count_images_per_interval_empty_days(self, s2_sr):
+        ic = s2_sr.filterDate("2021-01-01", "2021-01-07")
+        reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
+        count_images_per_interval = reduced.aggregate_array("n_images_per_interval").getInfo()
+        assert count_images_per_interval == [0, 1, 0]
+
 
 class TestClosestDate:
     """Test the ``closestDate`` method."""

--- a/tests/test_ImageCollection.py
+++ b/tests/test_ImageCollection.py
@@ -384,7 +384,7 @@ class TestReduceInterval:
         ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
         reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
         firstImg = reduced.first()
-        assert firstImg.get('n_images_per_interval').getInfo() == 24
+        assert firstImg.get("n_images_per_interval").getInfo() == 24
 
     def test_reduce_interval_with_count_images_per_interval_empty_days(self, s2_sr):
         ic = s2_sr.filterDate("2021-01-01", "2021-01-07")

--- a/tests/test_ImageCollection.py
+++ b/tests/test_ImageCollection.py
@@ -10,6 +10,7 @@ import pytest
 from ee.ee_exception import EEException
 from jsonschema import validate
 from matplotlib import pyplot as plt
+import geetools as geetools
 
 
 def reduce(
@@ -373,24 +374,31 @@ class TestReduceInterval:
         firstImg = ic.first()
         assert "system:id" in firstImg.propertyNames().getInfo()
 
+    def test_reduce_interval_without_count_images_per_interval(self, jaxa_rainfall):
+        # get 3 month worth of data and group it with default parameters
+        ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
+        reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=False)
+        firstImg = reduced.first()
+        assert "__geetools_generated_size__" not in firstImg.propertyNames().getInfo()
+
     def test_reduce_interval_with_count_images_per_interval(self, jaxa_rainfall):
         # get 3 month worth of data and group it with default parameters
         ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
         reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
         firstImg = reduced.first()
-        assert "n_images_per_interval" in firstImg.propertyNames().getInfo()
+        assert "__geetools_generated_size__" in firstImg.propertyNames().getInfo()
 
     def test_reduce_interval_with_count_images_per_interval_count(self, jaxa_rainfall):
         ic = jaxa_rainfall.filterDate("2020-01-01", "2020-01-02")
         reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
         firstImg = reduced.first()
-        assert firstImg.get("n_images_per_interval").getInfo() == 24
+        assert firstImg.get("__geetools_generated_size__").getInfo() == 24
 
     def test_reduce_interval_with_count_images_per_interval_empty_days(self, s2_sr):
         ic = s2_sr.filterDate("2021-01-01", "2021-01-07")
         reduced = ic.geetools.reduceInterval("mean", duration=1, unit="day", count_images_per_interval=True)
-        count_images_per_interval = reduced.aggregate_array("n_images_per_interval").getInfo()
-        assert count_images_per_interval == [0, 1, 0]
+        count_images_per_interval = reduced.aggregate_array("__geetools_generated_size__").getInfo()
+        assert count_images_per_interval == [17, 8, 11]
 
 
 class TestClosestDate:

--- a/tests/test_ImageCollection.py
+++ b/tests/test_ImageCollection.py
@@ -10,6 +10,7 @@ import pytest
 from ee.ee_exception import EEException
 from jsonschema import validate
 from matplotlib import pyplot as plt
+
 import geetools as geetools
 
 


### PR DESCRIPTION
The objective is to keep a track of the amount of images used on the temporal aggregation to facilitate further filtering on incomplete time ranges.

I've reused / renamed  the sizeName variable on the groupInterval to achieve that and created a flag to delete this prop if needed

I don't think we need to asset this using something like ee.Algorithms.if() because the count_images_per_interval flag is used only to modify the ops graph (and not in the graph itself)